### PR TITLE
add link to github issues

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -50,3 +50,7 @@ navigation:
 
   - title: API
     location: api.md
+
+site_footer_links:
+  - title: 'Report an issue on this site'
+    location: https://github.com/canonical-docs/landscape-docs/issues


### PR DESCRIPTION
This gives viewers of the doc an easy way to get to the github issues page, or even contribute themselves.