### PR TITLE
landscape-install-quickstart Setup first user https://<servername> fix

### DIFF
--- a/en/landscape-install-quickstart.md
+++ b/en/landscape-install-quickstart.md
@@ -26,7 +26,7 @@ If you have a valid LDS license, copy it over to `/etc/landscape/license.txt` an
 ```
 
 ## Setup first user
-The first user that is created in LDS automatically becomes the administrator of the "standalone" account. To create it, please go to https://<servername> and fill in the requested information.
+The first user that is created in LDS automatically becomes the administrator of the "standalone" account. To create it, please go to `https://<servername>` and fill in the requested information.
 == Registering clients ==
 In order to register a computer with LDS, you need to install the `landscape-client` package:
 ```


### PR DESCRIPTION
Fixed "https:// " in https://docs.ubuntu.com/landscape/en/landscape-install-quickstart
Setup first user
The first user that is created in LDS automatically becomes the administrator of the "standalone" account. To create it, please go to https:// and fill in the requested information.